### PR TITLE
Add example `.py` file for 1D Burgers problem 

### DIFF
--- a/examples/burgers.yaml
+++ b/examples/burgers.yaml
@@ -1,0 +1,22 @@
+data_path: "/home/mogab/code/dev/neuraloperator/data/burgers_data_R10.pth"
+n_train: 1000
+n_test: 100
+train_batch_size: 32
+test_batch_size: 32
+learning_rate: 0.001
+
+# Let the number of epochs be small just for running the documentation.
+# In practice, this should be on the order of 500.
+epochs: 50
+
+# Expected to be: epochs * (n_train // train_batch_size)
+iterations: 1_500
+modes: 16
+width: 48
+subsampling_rate: 8
+
+# Expected to be 8192 // subsampling_rate
+s: 1024
+
+# Expected to be equal to ``s``
+h: 1024

--- a/examples/plot_burgers.py
+++ b/examples/plot_burgers.py
@@ -1,0 +1,212 @@
+"""
+Training a 1D FNO on the Burgers Equation
+=========================================
+
+This notebooks walks through the Fourier Neural Operator for a 1D problem such
+as the (time-independent) Burgers equation discussed in Section 5.1 in the paper
+[Fourier Neural Operator for Parametric Partial Differential Equations](https://arxiv.org/pdf/2010.08895.pdf).
+The solution operator maps the field equation $A(x)$ at time $t=0$
+to $U(x)$ at time $t=1$.
+"""
+
+from typing import NamedTuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+from timeit import default_timer
+import yaml
+
+from torch.nn.functional import mse_loss
+import torch
+
+from neuralop import count_params
+from neuralop.datasets import load_burgers
+from neuralop.layers import SpectralConv1d
+from neuralop.models import FNO1d
+from neuralop.training import LpLoss
+
+np.random.seed(0)
+torch.manual_seed(0)
+
+# %%
+# Load configurations that control the training and evaluation of the FNO model:
+
+class Config(NamedTuple):
+  data_path: str
+  """Fully qualified file path to training/testing data"""
+  n_train: int
+  n_test: int
+  train_batch_size: int
+  test_batch_size: int
+  learning_rate: float
+  epochs: int
+  iterations: int
+  modes: int
+  width: int
+  subsampling_rate: int
+  s: int
+  h: int
+
+  @staticmethod
+  def from_yaml(config_path: str):
+    with open(config_path, 'r') as f:
+      cfg = yaml.load(f)
+
+    config = Config(
+      data_path=cfg['data_path'],
+      n_train=cfg['n_train'],
+      n_test=cfg['n_test'],
+      train_batch_size=cfg['train_batch_size'],
+      test_batch_size=cfg['test_batch_size'],
+      learning_rate=cfg['learning_rate'],
+      epochs=cfg['epochs'],
+      iterations=cfg['iterations'],
+      modes=cfg['modes'],
+      width=cfg['width'],
+      subsampling_rate=cfg['subsampling_rate'],
+      s=cfg['s'],
+      h=cfg['h'],
+    )
+    return config
+
+
+config = Config.from_yaml('burgers.yaml')
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+print(f'device={device}')
+
+# %%
+# Read Burgers data from disk. If the data is not found in the given directory,
+# TODO download it from Zenodo and proceed to load, train, and evaluate.
+
+# Data is of the shape (number of samples, grid size)
+train_loader, test_loader = load_burgers(
+    config.data_path,
+    config.n_train,
+    config.n_test,
+    batch_test=1
+)
+
+model = FNO1d(
+  # modes_height : number of Fourier modes to keep along the height
+  int(config.modes),
+
+  # hidden_channels : width of the FNO (i.e. number of channels)
+  int(config.width),
+
+  in_channels=2,
+  use_mlp=True,
+  SpectralConv=SpectralConv1d,
+  decompostion_kwargs={'dtype', torch.cdouble},
+  fno_block_precision='double',
+  dtype=torch.float64,
+).cuda()
+print(F"Model parameter count: {count_params(model):,d}")
+
+# %%
+# Training and Evaluation.
+# We use visually evaluate (i.e. print to console the loss of) the model using
+# mean squared error (MSE) in addition to training on L2 loss. The MSE will be
+# measured point-wise on predicted field function $U(x, t=1)$ for each
+# discretized point (i.e. by x-value).
+
+optimizer = torch.optim.Adam(
+    model.parameters(),
+    lr=config.learning_rate,
+    weight_decay=1e-4
+)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+    optimizer, T_max=config.iterations)
+
+loss = LpLoss()
+header_strings = (
+  'Epoch',
+  'Duration',
+  'Training MSE',
+  'Training L2',
+  'Testing L2',
+)
+HEADER = ' | '.join(header_strings)
+for ep in range(int(config.epochs)):
+    model.train()
+    t1 = default_timer()
+    train_mse = 0
+    train_l2 = 0
+
+    for x, y in train_loader:
+        x, y = x.to(device), y.to(device)
+
+        optimizer.zero_grad()
+        out = model(x)
+
+        mse = mse_loss(
+            out.view(config.train_batch_size, -1),
+            y.view(config.train_batch_size, -1),
+            reduction='mean'
+        )
+        l2 = loss(
+            out.view(config.train_batch_size, -1),
+            y.view(config.train_batch_size, -1)
+        )
+        l2.backward() # use the l2 relative loss
+
+        optimizer.step()
+        scheduler.step()
+        train_mse += mse.item()
+        train_l2 += l2.item()
+
+    model.eval()
+    test_l2 = 0.0
+    with torch.no_grad():
+        for x, y in test_loader:
+            x, y = x.to(device), y.to(device)
+
+            out = model(x)
+            test_l2 += loss(
+                out.view(config.test_batch_size, -1),
+                y.view(config.test_batch_size, -1)
+            ).item()
+
+    train_mse /= len(train_loader)
+    train_l2 /= config.n_train
+    test_l2 /= config.n_test
+    t2 = default_timer()
+
+    if ep % 10 == 0:
+        print(HEADER)
+    row = ' | '.join(
+        [f'{ep:{len(header_strings[0])}d}', f'{t2 - t1:{len(header_strings[1])}.3f}'] +
+        [f'{x:{len(s)}.6f}' for s, x
+         in zip(header_strings[2:], (train_mse,
+                                     train_l2,
+                                     test_l2))])
+    print(row)
+
+# %%
+# Plot Input/Truth/Predictions for a subset of test data.
+# Note we can barely see the Ground Truth curve above, so the model's prediction
+# already agrees with the solver that generated this Burgers dataset to within
+# a small error.
+
+test_samples = test_loader.dataset
+
+fig, axs = plt.subplots(2, 2, figsize=(10, 6)) # , layout='constrained')
+for index, ax in enumerate(axs.flat):
+    data = test_samples[index * 10]
+    # Input ``a`` & Ground-truth ``u``
+    a, u = data[0].to(device), data[1].to(device)
+    # Model prediction
+    out = model(a.unsqueeze(0))
+    ax.plot(
+        a[0].cpu(),
+        label="Input `x`")
+    ax.plot(
+        u.squeeze().cpu(),
+        label="Ground-truth `y`")
+    ax.plot(
+        out.squeeze().detach().cpu().numpy(),
+        label="Model prediction")
+    plt.xticks([], [])
+
+fig.suptitle('Inputs, ground-truth output and prediction.', y=0.98)
+plt.tight_layout()
+plt.legend(loc='lower right')

--- a/neuralop/__init__.py
+++ b/neuralop/__init__.py
@@ -1,8 +1,7 @@
 __version__ = '0.2.1'
 
+from . import datasets, layers, mpu
 from .models import TFNO3d, TFNO2d, TFNO1d, TFNO
 from .models import get_model
-from . import datasets
-from . import mpu
-from .training import Trainer
-from .training import LpLoss, H1Loss
+from .training import H1Loss, LpLoss, Trainer
+from .utils import count_params

--- a/neuralop/datasets/__init__.py
+++ b/neuralop/datasets/__init__.py
@@ -1,9 +1,13 @@
-# from .burgers import load_burgers
+from .burgers import load_burgers
 from .darcy import load_darcy_pt, load_darcy_flow_small
-from .spherical_swe import load_spherical_swe
-from .navier_stokes import load_navier_stokes_pt 
-#, load_navier_stokes_zarr
-# from .navier_stokes import load_navier_stokes_hdf5
-
-# from .positional_encoding import append_2d_grid_positional_encoding, get_grid_positional_encoding
 from .pt_dataset import load_pt_traintestsplit
+from .navier_stokes import load_navier_stokes_pt
+from .spherical_swe import load_spherical_swe
+
+# from .navier_stokes import load_navier_stokes_hdf5
+# from .navier_stokes import load_navier_stokes_zarr
+
+# from .positional_encoding import (
+#   append_2d_grid_positional_encoding,
+#   get_grid_positional_encoding,
+# )

--- a/neuralop/datasets/burgers.py
+++ b/neuralop/datasets/burgers.py
@@ -1,19 +1,51 @@
 from pathlib import Path
+from typing import Tuple, Union
+
 import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from neuralop.datasets.npz_dataset import fetch_npz
 
 
 def load_burgers(
-    data_path, n_train, n_test, batch_train=32, batch_test=100, time=1, grid=[0, 1]
-):
+    data_home: Union[str, Path],
+    file_name: str,
+    n_train,
+    n_test,
+    downsample_rate=8,
+    batch_train=32,
+    batch_test=100,
+    grid=(0, 1),
+) -> Tuple[DataLoader, DataLoader]:
+    """Loads the 1D Burgers dataset from an ``.npz`` data file.
 
-    data_path = Path(data_path).joinpath("burgers.pt").as_posix()
-    data = torch.load(data_path)
+    Target datafile will be read like a dict with initial (i.e. input) field
+    values ``a(x, t=0)`` at key "a" and final (i.e. output to learn) field
+    values ``u(x, t=1)`` at key "u".
 
-    x_train = data[0:n_train, :, 0]
-    x_test = data[n_train : (n_train + n_test), :, 0]
+    Parameters
+    ----------
+    data_home : str | PathLike[str]
+        Fully qualified path to a directory containing the target ``.npz`` file.
+    downsample_rate : int, optional (default=8)
+        How much data to skip (as in a list slice) in DataLoader when training
+        an operator. Ex: ``downsample_rate=1`` learns from all data, while
+        ``downsample_rate=10`` learns from 10% of the original data.
 
-    y_train = data[0:n_train, :, time]
-    y_test = data[n_train : (n_train + n_test), :, time]
+    Returns
+    -------
+    A tuple like ``(train_loader, test_loader)`` containing two
+    ``torch.utils.data.DataLoader``s
+    """
+    data = fetch_npz(file_name, "", data_home)  # unused zenodo_url
+    x_data: torch.Tensor = torch.tensor(data.a[:, :, ::downsample_rate])
+    y_data: torch.Tensor = torch.tensor(data.u[:, :, ::downsample_rate])
+
+    x_train = x_data[0:n_train, :, :]
+    x_test = x_data[n_train : (n_train + n_test), :, :]
+
+    y_train = y_data[0:n_train, :, :]
+    y_test = y_data[n_train : (n_train + n_test), :, :]
 
     s = x_train.size(-1)
 
@@ -23,16 +55,17 @@ def load_burgers(
         grid_train = grid.repeat(n_train, 1)
         grid_test = grid.repeat(n_test, 1)
 
-        x_train = torch.cat((x_train.unsqueeze(1), grid_train.unsqueeze(1)), 1)
-        x_test = torch.cat((x_test.unsqueeze(1), grid_test.unsqueeze(1)), 1)
+        # ``x_data`` is already unsqueezed
+        x_train = torch.cat((x_train, grid_train.unsqueeze(1)), 1)
+        x_test = torch.cat((x_test, grid_test.unsqueeze(1)), 1)
 
-    train_loader = torch.utils.data.DataLoader(
-        torch.utils.data.TensorDataset(x_train, y_train),
+    train_loader = DataLoader(
+        TensorDataset(x_train, y_train),
         batch_size=batch_train,
         shuffle=False,
     )
-    test_loader = torch.utils.data.DataLoader(
-        torch.utils.data.TensorDataset(x_test, y_test),
+    test_loader = DataLoader(
+        TensorDataset(x_test, y_test),
         batch_size=batch_test,
         shuffle=False,
     )

--- a/neuralop/datasets/darcy.py
+++ b/neuralop/datasets/darcy.py
@@ -52,7 +52,7 @@ def load_darcy_flow_small(
         if res not in [16, 32]:
             raise ValueError(
                 f"Only 32 and 64 are supported for test resolution, "
-                f"but got test_resolutions={test_resolutions}"
+                f"but got {test_resolutions=}"
             )
     path = Path(__file__).resolve().parent.joinpath("data")
     return load_darcy_pt(
@@ -169,7 +169,7 @@ def load_darcy_pt(
     ):
         print(
             f"Loading test db at resolution {res} with {n_test} samples "
-            f"and batch-size={test_batch_size}"
+            f"and {test_batch_size=}"
         )
         data = torch.load(Path(data_path).joinpath(f"darcy_test_{res}.pt").as_posix())
         x_test = (

--- a/neuralop/datasets/hdf5_dataset.py
+++ b/neuralop/datasets/hdf5_dataset.py
@@ -19,8 +19,7 @@ class H5pyDataset(Dataset):
             subsample_step = resolution_to_step[resolution]
         except KeyError:
             raise ValueError(
-                f"Got resolution={resolution}, "
-                f"expected one of {resolution_to_step.keys()}"
+                f"Got {resolution=}, expected one of {resolution_to_step.keys()}"
             )
 
         self.subsample_step = subsample_step

--- a/neuralop/datasets/navier_stokes.py
+++ b/neuralop/datasets/navier_stokes.py
@@ -53,7 +53,8 @@ def load_navier_stokes_zarr(data_path, n_train, batch_size,
 
     test_loaders = dict()
     for (res, n_test, test_batch_size) in zip(test_resolutions, n_tests, test_batch_sizes):
-        print(f'Loading test db at resolution {res} with {n_test} samples and batch-size={test_batch_size}')
+        print(f'Loading test db at resolution {res} with {n_test} samples and '
+              f'{test_batch_size=}')
         transform_x = []
         transform_y = None
         if encode_input:
@@ -120,7 +121,8 @@ def load_navier_stokes_hdf5(data_path, n_train, batch_size,
 
     test_loaders = dict()
     for (res, n_test, test_batch_size) in zip(test_resolutions, n_tests, test_batch_sizes):
-        print(f'Loading test db at resolution {res} with {n_test} samples and batch-size={test_batch_size}')
+        print(f'Loading test db at resolution {res} with {n_test} samples and '
+              f'{test_batch_size=}')
         transform_x = []
         transform_y = None
         if encode_input:
@@ -214,7 +216,8 @@ def load_navier_stokes_pt(data_path, train_resolution,
 
     test_loaders =  {train_resolution: test_loader}
     for (res, n_test, test_batch_size) in zip(test_resolutions, n_tests, test_batch_sizes):
-        print(f'Loading test db at resolution {res} with {n_test} samples and batch-size={test_batch_size}')
+        print(f'Loading test db at resolution {res} with {n_test} samples '
+              f'and {test_batch_size=}')
         x_test, y_test = _load_navier_stokes_test_HR(data_path, n_test, resolution=res, channel_dim=channel_dim)
         if input_encoder is not None:
             x_test = input_encoder.encode(x_test)

--- a/neuralop/datasets/npz_dataset.py
+++ b/neuralop/datasets/npz_dataset.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from typing import Optional, Union
+
+from numpy import load as np_load
+
+DEFAULT_DATA_HOME = Path.home().joinpath("neuraloperator_data")
+
+
+def _get_data_home(data_home: Optional[str, Path] = None) -> Path:
+    if data_home is None:
+        data_home = DEFAULT_DATA_HOME
+    if isinstance(data_home, str):
+        data_home = Path(data_home)
+
+    if not data_home.exists():
+        data_home.mkdir()
+
+    return data_home
+
+
+def fetch_npz(
+    file_name: str,
+    unused_zenodo_url: str,
+    data_home: Optional[Union[str, Path]] = None,
+):
+    """Loads a target ``.npz`` file.
+
+    This does not download the target file (though future versions of this
+    function will automatically download the specified file
+    if it's not on disk).
+
+    Parameters
+    ----------
+    data_home : str, default=None
+        Specify a download folder for the datasets. If None,
+        all neuraloperator data is stored in "~/neuraloperator_data" subfolders.
+    """
+    data_home = _get_data_home(data_home)
+    file_path = data_home / file_name
+    try:
+        return np_load(str(file_path))
+    except FileNotFoundError:
+        raise NotImplementedError(
+            f"File {file_path} not found on disk. "
+            f"Please make sure {file_name} is in the target directory "
+            f"and try again"
+        )

--- a/neuralop/datasets/spherical_swe.py
+++ b/neuralop/datasets/spherical_swe.py
@@ -9,13 +9,15 @@ def load_spherical_swe(n_train, n_tests, batch_size, test_batch_sizes,
                   device=torch.device('cpu')):
     """Load the Spherical Shallow Water equations Dataloader"""
 
-    print(f'Loading train dataloader at resolution {train_resolution} with {n_train} samples and batch-size={batch_size}')
+    print(f'Loading train dataloader at resolution {train_resolution} '
+          f'with {n_train} samples and {batch_size=}')
     train_dataset = SphericalSWEDataset(dims=train_resolution, num_examples=n_train, device=device)
     train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=0, persistent_workers=False)
 
     test_loaders =  dict()
     for (res, n_test, test_batch_size) in zip(test_resolutions, n_tests, test_batch_sizes):
-        print(f'Loading test dataloader at resolution {res} with {n_test} samples and batch-size={test_batch_size}')
+        print(f'Loading test dataloader at resolution {res} '
+              f'with {n_test} samples and {test_batch_size=}')
 
         test_dataset = SphericalSWEDataset(dims=res, num_examples=n_test, device=device)
         test_loader = DataLoader(test_dataset, batch_size=test_batch_size, shuffle=True, num_workers=0, persistent_workers=False)

--- a/neuralop/datasets/zarr_dataset.py
+++ b/neuralop/datasets/zarr_dataset.py
@@ -19,8 +19,7 @@ class ZarrDataset(Dataset):
             subsample_step = resolution_to_step[resolution]
         except KeyError:
             raise ValueError(
-                f"Got resolution={resolution}, "
-                f"expected one of {resolution_to_step.keys()}"
+                f"Got {resolution=}, expected one of {resolution_to_step.keys()}"
             )
 
         self.subsample_step = subsample_step

--- a/neuralop/layers/__init__.py
+++ b/neuralop/layers/__init__.py
@@ -1,0 +1,1 @@
+from spectral_convolution import SpectralConv, SpectralConv1d

--- a/neuralop/layers/fno_block.py
+++ b/neuralop/layers/fno_block.py
@@ -169,7 +169,7 @@ class FNOBlocks(nn.Module):
             )
         else:
             raise ValueError(
-                f"Got norm={norm} but expected None or one of "
+                f"Got {norm=} but expected None or one of "
                 "[instance_norm, group_norm, layer_norm]"
             )
 

--- a/neuralop/layers/integral_transform.py
+++ b/neuralop/layers/integral_transform.py
@@ -57,7 +57,6 @@ class IntegralTransform(nn.Module):
         mlp_non_linearity=F.gelu,
         transform_type="linear",
     ):
-
         super().__init__()
 
         assert mlp is not None or mlp_layers is not None

--- a/neuralop/layers/padding.py
+++ b/neuralop/layers/padding.py
@@ -69,8 +69,8 @@ class DomainPadding(nn.Module):
 
             if verbose:
                 print(
-                    f"Padding inputs of resolution={resolution} with "
-                    f"padding={padding}, {self.padding_mode}"
+                    f"Padding inputs of {resolution=} "
+                    f"with {padding=}, {self.padding_mode}"
                 )
 
             # padding is being applied in reverse order
@@ -116,7 +116,7 @@ class DomainPadding(nn.Module):
                 unpad_indices = (Ellipsis,) + tuple(unpad_list)
                 padding = [i for p in padding for i in (0, p)]
             else:
-                raise ValueError(f"Got padding_mode={self.padding_mode}")
+                raise ValueError(f"Got {self.padding_mode=}")
 
             self._padding[f"{resolution}"] = padding
 

--- a/neuralop/layers/skip_connections.py
+++ b/neuralop/layers/skip_connections.py
@@ -45,7 +45,7 @@ def skip_connection(
         return nn.Identity()
     else:
         raise ValueError(
-            f"Got skip-connection type={skip_type}, expected one of"
+            f"Got skip-connection {skip_type=}, expected one of"
             f" {'soft-gating', 'linear', 'id'}."
         )
 
@@ -72,7 +72,7 @@ class SoftGating(nn.Module):
         super().__init__()
         if out_features is not None and in_features != out_features:
             raise ValueError(
-                f"Got in_features={in_features} and out_features={out_features}"
+                f"Got {in_features=} and {out_features=}"
                 "but these two must be the same for soft-gating"
             )
         self.in_features = in_features

--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -178,7 +178,7 @@ def get_contract_fun(weight, implementation="reconstructed", separable=False):
             )
     else:
         raise ValueError(
-            f'Got implementation={implementation}, expected "reconstructed" or "factorized"'
+            f'Got {implementation=}, expected "reconstructed" or "factorized"'
         )
 
 
@@ -320,8 +320,7 @@ class SpectralConv(nn.Module):
             if in_channels != out_channels:
                 raise ValueError(
                     "To use separable Fourier Conv, in_channels must be equal "
-                    f"to out_channels, but got in_channels={in_channels} and "
-                    f"out_channels={out_channels}",
+                    f"to out_channels, but got {in_channels=} and {out_channels=}",
                 )
             weight_shape = (in_channels, *half_total_n_modes)
         else:
@@ -390,8 +389,7 @@ class SpectralConv(nn.Module):
                     self._incremental_n_modes = incremental_n_modes
                 else:
                     raise ValueError(
-                        f"Provided {incremental_n_modes} for actual "
-                        f"n_modes={self.n_modes}."
+                        f"Provided {incremental_n_modes} for actual {self.n_modes=}."
                     )
             self.weight_slices = [slice(None)] * 2 + [
                 slice(None, n // 2) for n in self._incremental_n_modes

--- a/neuralop/layers/spherical_convolution.py
+++ b/neuralop/layers/spherical_convolution.py
@@ -193,8 +193,7 @@ def get_contract_fun(weight, implementation="reconstructed", separable=False):
             )
     else:
         raise ValueError(
-            f'Got implementation={implementation}, expected "reconstructed" or '
-            f'"factorized"'
+            f'Got {implementation=}, expected "reconstructed" or "factorized"'
         )
 
 
@@ -279,8 +278,7 @@ class SphericalConv(nn.Module):
             if in_channels != out_channels:
                 raise ValueError(
                     "To use separable Fourier Conv, in_channels must be equal "
-                    f"to out_channels, but got in_channels={in_channels} "
-                    f"and out_channels={out_channels}",
+                    f"to out_channels, but got {in_channels=} and {out_channels=}",
                 )
             weight_shape = (in_channels, *half_total_n_modes[:-1])
         else:
@@ -397,8 +395,7 @@ class SphericalConv(nn.Module):
                     self._incremental_n_modes = incremental_n_modes
                 else:
                     raise ValueError(
-                        f"Provided {incremental_n_modes} for actual"
-                        f" n_modes={self.n_modes}."
+                        f"Provided {incremental_n_modes} for actual {self.n_modes}."
                     )
             self.weight_slices = [slice(None)] * 2 + [
                 slice(None, n // 2) for n in self._incremental_n_modes

--- a/neuralop/models/fnogno.py
+++ b/neuralop/models/fnogno.py
@@ -17,15 +17,15 @@ class FNOGNO(nn.Module):
 
         Parameters
         ----------
-        in_channels : _type_
+        in_channels : int
             number of input channels
-        out_channels : _type_
+        out_channels : int
             number of output channels
         projection_channels : int, optional
              number of hidden channels in embedding block of FNO. Defaults to 256.
         gno_coord_dim : int, optional
             dimension of GNO input data. Defaults to 3.
-        gno_coord_embed_dim : _type_, optional
+        gno_coord_embed_dim : int, optional
             dimension of embeddings of GNO coordinates. Defaults to None.
         gno_radius : float, optional
             radius parameter to construct graph. Defaults to 0.033.
@@ -67,7 +67,7 @@ class FNOGNO(nn.Module):
             By default None, otherwise tanh is used before FFT in the FNO block. 
         fno_norm : nn.Module, optional
             normalization layer to use. Defaults to None.
-        fno_ada_in_features : _type_, optional
+        fno_ada_in_features : int, optional
             if an adaptive mesh is used, number of channels of its positional embedding. Defaults to None.
         fno_ada_in_dim : int, optional
             dimensions of above FNO adaptive mesh. Defaults to 1.

--- a/neuralop/models/fnogno.py
+++ b/neuralop/models/fnogno.py
@@ -15,56 +15,96 @@ from ..layers.neighbor_search import NeighborSearch
 class FNOGNO(nn.Module):
     """FNOGNO: Fourier/Geometry Neural Operator 
 
-        Args:
-            in_channels (int): number of input channels
-            out_channels (int): number of output channels
-            projection_channels (int, optional): number of hidden channels in embedding block of FNO. Defaults to 256.
-            gno_coord_dim (int, optional): dimension of GNO input data. Defaults to 3.
-            gno_coord_embed_dim (int, optional): dimension of embeddings of GNO coordinates. Defaults to None.
-            gno_radius (float, optional): radius parameter to construct graph. Defaults to 0.033.
-            gno_mlp_hidden_layers (list, optional): dimension of hidden MLP layers of GNO. Defaults to [512, 256].
-            gno_mlp_non_linearity (nn.Functional activation, optional): _description_. Defaults to F.gelu.
-            gno_transform_type (str, optional): type of integral transform to apply in GNO. Defaults to 'linear'.
-                options: 'linear_kernelonly' 
-                         'linear' 
-                         'nonlinear_kernelonly' 
-                         'nonlinear'
-            gno_use_open3d (bool, optional): whether to use Open3D functionality. Defaults to False.
-            fno_n_modes (tuple, optional): number of modes to keep along each spectral dimension of FNO block. Defaults to (16, 16, 16).
-            fno_hidden_channels (int, optional): number of hidden channels of fno block.. Defaults to 64.
-            fno_lifting_channels (int, optional): dimension of hidden layers in FNO lifting block. Defaults to 256.
-            fno_n_layers (int, optional): number of FNO layers in the block. Defaults to 4.
-            fno_output_scaling_factor (float, optional): factor by which to rescale output predictions in the original domain. Defaults to None.
-            fno_incremental_n_modes (int tuple, optional): if passed, sets n_modes separately for each FNO layer. Defaults to None.
-            fno_block_precision (str, optional): _description_. Defaults to 'full'.
-            fno_use_mlp (bool, optional): Whether to use an MLP layer after each FNO block. Defaults to False.
-            fno_mlp_dropout (int, optional): dropout parameter of above MLP. Defaults to 0.
-            fno_mlp_expansion (float, optional): expansion parameter of above MLP. Defaults to 0.5.
-            fno_non_linearity (nn.Module, optional): nonlinear activation function between each FNO layer. Defaults to F.gelu.
-            fno_stabilizer (str {'tanh'} or none, optional): By default None, otherwise tanh is used before FFT in the FNO block. 
-            fno_norm (F.module, optional): normalization layer to use. Defaults to None.
-            fno_ada_in_features (int, optional): if an adaptive mesh is used, number of channels of its positional embedding. Defaults to None.
-            fno_ada_in_dim (int, optional): dimensions of above FNO adaptive mesh. Defaults to 1.
-            fno_preactivation (bool, optional): whether to use Resnet-style preactivation. Defaults to False.
-            fno_skip (str {'linear', 'identity', 'soft-gating'}, optional): type of skip connection to use. Defaults to 'linear'.
-            fno_mlp_sfip (str, optional): _description_. Defaults to 'soft-gating'.
-            fno_separable (bool, optional): if True, use a depthwise separable spectral convolution. Defaults to False.
-            fno_factorization (str {'tucker', 'cp', 'tt'} or None, optional): Tensor factorization of the parameters weight to use. Defaults to None.
-                * If None, a dense tensor parametrizes the Spectral convolutions
-                * Otherwise, the specified tensor factorization is used.
-            fno_rank (float, optional): Rank of the tensor factorization of the Fourier weights. Defaults to 1.0.
-            fno_joint_factorization (bool, optional): Whether all the Fourier layers should be parameterized by a single tensor (vs one per layer). Defaults to False.
-            fno_fixed_rank_modes (bool, optional): Modes to not factorize. Defaults to False.
-            fno_implementation (str {'factorized', 'reconstructed'}, optional): _description_. Defaults to 'factorized'.
-                If factorization is not None, forward mode to use::
-                * `reconstructed` : the full weight tensor is reconstructed from the factorization and used for the forward pass
-                * `factorized` : the input is directly contracted with the factors of the decomposition
-            fno_decomposition_kwargs (dict, optional):  Optionaly additional parameters to pass to the tensor decomposition. Defaults to dict()
-            fno_domain_padding (None or float, optional): If not None, percentage of padding to use. Defaults to None.
-            fno_domain_padding_mode (str {'symmetric', 'one-sided'}, optional): How to perform domain padding. Defaults to 'one-sided'.
-            fno_fft_norm (str, optional): norm mode of FFT. Defaults to 'forward'.
-            fno_SpectralConv (nn.Module, optional): Spectral Convolution module to use. Defaults to SpectralConv.
+        Parameters
+        ----------
+        in_channels : _type_
+            number of input channels
+        out_channels : _type_
+            number of output channels
+        projection_channels : int, optional
+             number of hidden channels in embedding block of FNO. Defaults to 256.
+        gno_coord_dim : int, optional
+            dimension of GNO input data. Defaults to 3.
+        gno_coord_embed_dim : _type_, optional
+            dimension of embeddings of GNO coordinates. Defaults to None.
+        gno_radius : float, optional
+            radius parameter to construct graph. Defaults to 0.033.
+        gno_mlp_hidden_layers : list, optional
+            dimension of hidden MLP layers of GNO. Defaults to [512, 256].
+        gno_mlp_non_linearity : nn.Module, optional
+            nonlinear activation function between layers, by default F.gelu
+        gno_transform_type : str, optional
+            type of integral transform to apply in GNO. Defaults to 'linear'.
+            options: 'linear_kernelonly' 
+                        'linear' 
+                        'nonlinear_kernelonly' 
+                        'nonlinear'
+        gno_use_open3d : bool, optional
+            whether to use Open3D functionality. Defaults to False.
+        fno_n_modes : tuple, optional
+            number of modes to keep along each spectral dimension of FNO block. Defaults to (16, 16, 16).
+        fno_hidden_channels : int, optional
+            number of hidden channels of fno block. Defaults to 64.
+        fno_lifting_channels : int, optional
+            dimension of hidden layers in FNO lifting block. Defaults to 256.
+        fno_n_layers : int, optional
+            number of FNO layers in the block. Defaults to 4.
+        fno_output_scaling_factor : float, optional
+            factor by which to rescale output predictions in the original domain. Defaults to None.
+        fno_incremental_n_modes : list[int], optional
+            if passed, sets n_modes separately for each FNO layer. Defaults to None.
+        fno_block_precision : str, optional
+            data precision to compute within fno block. defaults to 'full'
+        fno_use_mlp : bool, optional
+            Whether to use an MLP layer after each FNO block. Defaults to False.
+        fno_mlp_dropout : float, optional
+            dropout parameter of above MLP. Defaults to 0.
+        fno_mlp_expansion : float, optional
+            expansion parameter of above MLP. Defaults to 0.5.
+        fno_non_linearity : nn.Module, optional
+            nonlinear activation function between each FNO layer. Defaults to F.gelu.
+        fno_stabilizer : nn.Module, optional
+            By default None, otherwise tanh is used before FFT in the FNO block. 
+        fno_norm : nn.Module, optional
+            normalization layer to use. Defaults to None.
+        fno_ada_in_features : _type_, optional
+            if an adaptive mesh is used, number of channels of its positional embedding. Defaults to None.
+        fno_ada_in_dim : int, optional
+            dimensions of above FNO adaptive mesh. Defaults to 1.
+        fno_preactivation : bool, optional
+            whether to use Resnet-style preactivation. Defaults to False.
+        fno_skip : str, optional
+            type of skip connection to use. Defaults to 'linear'.
+        fno_mlp_skip : str, optional
+            type of mlp skip connection to use, by default 'soft-gating'
+        fno_separable : bool, optional
+            if True, use a depthwise separable spectral convolution. Defaults to False.
+        fno_factorization : str {'tucker', 'tt', 'cp'}, optional
+            Tensor factorization of the parameters weight to use. Defaults to None.
+        fno_rank : float, optional
+            Rank of the tensor factorization of the Fourier weights. Defaults to 1.0.
+        fno_joint_factorization : bool, optional
+            Whether all the Fourier layers should be parameterized by a single tensor (vs one per layer). Defaults to False.
+        fno_fixed_rank_modes : bool, optional
+            Modes to not factorize. Defaults to False.
+        fno_implementation : str {'factorized', 'reconstructed'}, optional
+            If factorization is not None, forward mode to use::
+            * `reconstructed` : the full weight tensor is reconstructed from the factorization and used for the forward pass
+            * `factorized` : the input is directly contracted with the factors of the decomposition
+        fno_decomposition_kwargs : dict, optional
+            Optionaly additional parameters to pass to the tensor decomposition. Defaults to dict()
+        fno_domain_padding : float, optional
+            If not None, percentage of padding to use. Defaults to None.
+        fno_domain_padding_mode : str {'symmetric', 'one-sided'}, optional
+            How to perform domain padding. Defaults to 'one-sided'.
+        fno_fft_norm : str, optional
+            normalization param of torch.fft to use in FNO. Defaults to 'forward'
+        fno_SpectralConv : nn.Module, optional
+             Spectral Convolution module to use. Defaults to SpectralConv.
         """
+    
+    
+    
     def __init__(
             self,
             in_channels,
@@ -108,6 +148,7 @@ class FNOGNO(nn.Module):
             fno_SpectralConv=SpectralConv,
             **kwargs
         ):
+        
         
         super().__init__()
 

--- a/neuralop/models/fnogno.py
+++ b/neuralop/models/fnogno.py
@@ -13,6 +13,58 @@ from ..layers.neighbor_search import NeighborSearch
 
 
 class FNOGNO(nn.Module):
+    """FNOGNO: Fourier/Geometry Neural Operator 
+
+        Args:
+            in_channels (int): number of input channels
+            out_channels (int): number of output channels
+            projection_channels (int, optional): number of hidden channels in embedding block of FNO. Defaults to 256.
+            gno_coord_dim (int, optional): dimension of GNO input data. Defaults to 3.
+            gno_coord_embed_dim (int, optional): dimension of embeddings of GNO coordinates. Defaults to None.
+            gno_radius (float, optional): radius parameter to construct graph. Defaults to 0.033.
+            gno_mlp_hidden_layers (list, optional): dimension of hidden MLP layers of GNO. Defaults to [512, 256].
+            gno_mlp_non_linearity (nn.Functional activation, optional): _description_. Defaults to F.gelu.
+            gno_transform_type (str, optional): type of integral transform to apply in GNO. Defaults to 'linear'.
+                options: 'linear_kernelonly' 
+                         'linear' 
+                         'nonlinear_kernelonly' 
+                         'nonlinear'
+            gno_use_open3d (bool, optional): whether to use Open3D functionality. Defaults to False.
+            fno_n_modes (tuple, optional): number of modes to keep along each spectral dimension of FNO block. Defaults to (16, 16, 16).
+            fno_hidden_channels (int, optional): number of hidden channels of fno block.. Defaults to 64.
+            fno_lifting_channels (int, optional): dimension of hidden layers in FNO lifting block. Defaults to 256.
+            fno_n_layers (int, optional): number of FNO layers in the block. Defaults to 4.
+            fno_output_scaling_factor (float, optional): factor by which to rescale output predictions in the original domain. Defaults to None.
+            fno_incremental_n_modes (int tuple, optional): if passed, sets n_modes separately for each FNO layer. Defaults to None.
+            fno_block_precision (str, optional): _description_. Defaults to 'full'.
+            fno_use_mlp (bool, optional): Whether to use an MLP layer after each FNO block. Defaults to False.
+            fno_mlp_dropout (int, optional): dropout parameter of above MLP. Defaults to 0.
+            fno_mlp_expansion (float, optional): expansion parameter of above MLP. Defaults to 0.5.
+            fno_non_linearity (nn.Module, optional): nonlinear activation function between each FNO layer. Defaults to F.gelu.
+            fno_stabilizer (str {'tanh'} or none, optional): By default None, otherwise tanh is used before FFT in the FNO block. 
+            fno_norm (F.module, optional): normalization layer to use. Defaults to None.
+            fno_ada_in_features (int, optional): if an adaptive mesh is used, number of channels of its positional embedding. Defaults to None.
+            fno_ada_in_dim (int, optional): dimensions of above FNO adaptive mesh. Defaults to 1.
+            fno_preactivation (bool, optional): whether to use Resnet-style preactivation. Defaults to False.
+            fno_skip (str {'linear', 'identity', 'soft-gating'}, optional): type of skip connection to use. Defaults to 'linear'.
+            fno_mlp_sfip (str, optional): _description_. Defaults to 'soft-gating'.
+            fno_separable (bool, optional): if True, use a depthwise separable spectral convolution. Defaults to False.
+            fno_factorization (str {'tucker', 'cp', 'tt'} or None, optional): Tensor factorization of the parameters weight to use. Defaults to None.
+                * If None, a dense tensor parametrizes the Spectral convolutions
+                * Otherwise, the specified tensor factorization is used.
+            fno_rank (float, optional): Rank of the tensor factorization of the Fourier weights. Defaults to 1.0.
+            fno_joint_factorization (bool, optional): Whether all the Fourier layers should be parameterized by a single tensor (vs one per layer). Defaults to False.
+            fno_fixed_rank_modes (bool, optional): Modes to not factorize. Defaults to False.
+            fno_implementation (str {'factorized', 'reconstructed'}, optional): _description_. Defaults to 'factorized'.
+                If factorization is not None, forward mode to use::
+                * `reconstructed` : the full weight tensor is reconstructed from the factorization and used for the forward pass
+                * `factorized` : the input is directly contracted with the factors of the decomposition
+            fno_decomposition_kwargs (dict, optional):  Optionaly additional parameters to pass to the tensor decomposition. Defaults to dict()
+            fno_domain_padding (None or float, optional): If not None, percentage of padding to use. Defaults to None.
+            fno_domain_padding_mode (str {'symmetric', 'one-sided'}, optional): How to perform domain padding. Defaults to 'one-sided'.
+            fno_fft_norm (str, optional): norm mode of FFT. Defaults to 'forward'.
+            fno_SpectralConv (nn.Module, optional): Spectral Convolution module to use. Defaults to SpectralConv.
+        """
     def __init__(
             self,
             in_channels,

--- a/neuralop/models/fnogno.py
+++ b/neuralop/models/fnogno.py
@@ -21,86 +21,91 @@ class FNOGNO(nn.Module):
             number of input channels
         out_channels : int
             number of output channels
-        projection_channels : int, optional
-             number of hidden channels in embedding block of FNO. Defaults to 256.
-        gno_coord_dim : int, optional
-            dimension of GNO input data. Defaults to 3.
-        gno_coord_embed_dim : int, optional
-            dimension of embeddings of GNO coordinates. Defaults to None.
-        gno_radius : float, optional
-            radius parameter to construct graph. Defaults to 0.033.
-        gno_mlp_hidden_layers : list, optional
-            dimension of hidden MLP layers of GNO. Defaults to [512, 256].
-        gno_mlp_non_linearity : nn.Module, optional
-            nonlinear activation function between layers, by default F.gelu
-        gno_transform_type : str, optional
-            type of integral transform to apply in GNO. Defaults to 'linear'.
-            options: 'linear_kernelonly' 
-                        'linear' 
-                        'nonlinear_kernelonly' 
-                        'nonlinear'
-        gno_use_open3d : bool, optional
-            whether to use Open3D functionality. Defaults to False.
-        fno_n_modes : tuple, optional
-            number of modes to keep along each spectral dimension of FNO block. Defaults to (16, 16, 16).
-        fno_hidden_channels : int, optional
-            number of hidden channels of fno block. Defaults to 64.
-        fno_lifting_channels : int, optional
-            dimension of hidden layers in FNO lifting block. Defaults to 256.
-        fno_n_layers : int, optional
-            number of FNO layers in the block. Defaults to 4.
-        fno_output_scaling_factor : float, optional
-            factor by which to rescale output predictions in the original domain. Defaults to None.
-        fno_incremental_n_modes : list[int], optional
-            if passed, sets n_modes separately for each FNO layer. Defaults to None.
-        fno_block_precision : str, optional
-            data precision to compute within fno block. defaults to 'full'
-        fno_use_mlp : bool, optional
-            Whether to use an MLP layer after each FNO block. Defaults to False.
-        fno_mlp_dropout : float, optional
-            dropout parameter of above MLP. Defaults to 0.
-        fno_mlp_expansion : float, optional
-            expansion parameter of above MLP. Defaults to 0.5.
-        fno_non_linearity : nn.Module, optional
-            nonlinear activation function between each FNO layer. Defaults to F.gelu.
-        fno_stabilizer : nn.Module, optional
+        projection_channels : int, defaults to 256
+             number of hidden channels in embedding block of FNO. 
+        gno_coord_dim : int, defaults to 3
+            dimension of GNO input data. 
+        gno_coord_embed_dim : int | None, defaults to none
+            dimension of embeddings of GNO coordinates. 
+        gno_radius : float, defaults to 0.033
+            radius parameter to construct graph. 
+        gno_mlp_hidden_layers : list, defaults to [512, 256]
+            dimension of hidden MLP layers of GNO. 
+        gno_mlp_non_linearity : nn.Module, defaults to F.gelu
+            nonlinear activation function between layers
+        gno_transform_type : str, defaults to 'linear'
+            type of kernel integral transform to apply in GNO. 
+            kernel k(x,y): parameterized as MLP integrated over a neighborhood of x
+            options: 'linear_kernelonly': integrand is k(x, y) 
+                        'linear' : integrand is k(x, y) * f(y)
+                        'nonlinear_kernelonly' : integrand is k(x, y, f(y))
+                        'nonlinear' : integrand is k(x, y, f(y)) * f(y)
+        gno_use_open3d : bool, defaults to False
+            whether to use Open3D functionality
+            if False, uses torch_scatter
+        fno_n_modes : tuple, defaults to (16, 16, 16)
+            number of modes to keep along each spectral dimension of FNO block
+        fno_hidden_channels : int, defaults to 64
+            number of hidden channels of fno block. 
+        fno_lifting_channels : int, defaults to 256
+            dimension of hidden layers in FNO lifting block.
+        fno_n_layers : int, defaults to 4
+            number of FNO layers in the block. 
+        fno_output_scaling_factor : float | None, defaults to None
+            factor by which to rescale output predictions in the original domain
+        fno_incremental_n_modes : list[int] | None, defaults to None
+            if passed, sets n_modes separately for each FNO layer. 
+        fno_block_precision : str, defaults to 'full'
+            data precision to compute within fno block
+        fno_use_mlp : bool, defaults to False
+            Whether to use an MLP layer after each FNO block. 
+        fno_mlp_dropout : float, defaults to 0
+            dropout parameter of above MLP. 
+        fno_mlp_expansion : float, defaults to 0.5
+            expansion parameter of above MLP. 
+        fno_non_linearity : nn.Module, defaults to F.gelu
+            nonlinear activation function between each FNO layer. 
+        fno_stabilizer : nn.Module | None, defaults to None
             By default None, otherwise tanh is used before FFT in the FNO block. 
-        fno_norm : nn.Module, optional
-            normalization layer to use. Defaults to None.
-        fno_ada_in_features : int, optional
-            if an adaptive mesh is used, number of channels of its positional embedding. Defaults to None.
-        fno_ada_in_dim : int, optional
-            dimensions of above FNO adaptive mesh. Defaults to 1.
-        fno_preactivation : bool, optional
-            whether to use Resnet-style preactivation. Defaults to False.
-        fno_skip : str, optional
-            type of skip connection to use. Defaults to 'linear'.
-        fno_mlp_skip : str, optional
-            type of mlp skip connection to use, by default 'soft-gating'
-        fno_separable : bool, optional
-            if True, use a depthwise separable spectral convolution. Defaults to False.
-        fno_factorization : str {'tucker', 'tt', 'cp'}, optional
-            Tensor factorization of the parameters weight to use. Defaults to None.
-        fno_rank : float, optional
-            Rank of the tensor factorization of the Fourier weights. Defaults to 1.0.
-        fno_joint_factorization : bool, optional
-            Whether all the Fourier layers should be parameterized by a single tensor (vs one per layer). Defaults to False.
-        fno_fixed_rank_modes : bool, optional
-            Modes to not factorize. Defaults to False.
-        fno_implementation : str {'factorized', 'reconstructed'}, optional
+        fno_norm : nn.Module | None, defaults to None
+            normalization layer to use in FNO.
+        fno_ada_in_features : int | None, defaults to None
+            if an adaptive mesh is used, number of channels of its positional embedding. 
+        fno_ada_in_dim : int, defaults to 1
+            dimensions of above FNO adaptive mesh. 
+        fno_preactivation : bool, defaults to False
+            whether to use Resnet-style preactivation. 
+        fno_skip : str, defaults to 'linear'
+            type of skip connection to use. 
+        fno_mlp_skip : str, defaults to 'soft-gating'
+            type of skip connection to use in the FNO
+            'linear': conv layer
+            'soft-gating': weights the channels of the input
+            'identity': nn.Identity
+        fno_separable : bool, defaults to False
+            if True, use a depthwise separable spectral convolution. 
+        fno_factorization : str {'tucker', 'tt', 'cp'} |  None, defaults to None
+            Tensor factorization of the parameters weight to use
+        fno_rank : float, defaults to 1.0
+            Rank of the tensor factorization of the Fourier weights. 
+        fno_joint_factorization : bool, defaults to False
+            Whether all the Fourier layers should be parameterized by a single tensor (vs one per layer). 
+        fno_fixed_rank_modes : bool, defaults to False
+            Modes to not factorize. 
+        fno_implementation : str {'factorized', 'reconstructed'} | None, defaults to 'factorized'
             If factorization is not None, forward mode to use::
             * `reconstructed` : the full weight tensor is reconstructed from the factorization and used for the forward pass
             * `factorized` : the input is directly contracted with the factors of the decomposition
-        fno_decomposition_kwargs : dict, optional
-            Optionaly additional parameters to pass to the tensor decomposition. Defaults to dict()
-        fno_domain_padding : float, optional
-            If not None, percentage of padding to use. Defaults to None.
-        fno_domain_padding_mode : str {'symmetric', 'one-sided'}, optional
-            How to perform domain padding. Defaults to 'one-sided'.
-        fno_fft_norm : str, optional
-            normalization param of torch.fft to use in FNO. Defaults to 'forward'
-        fno_SpectralConv : nn.Module, optional
-             Spectral Convolution module to use. Defaults to SpectralConv.
+        fno_decomposition_kwargs : dict, defaults to dict()
+            Optionaly additional parameters to pass to the tensor decomposition. 
+        fno_domain_padding : float | None, defaults to None
+            If not None, percentage of padding to use. 
+        fno_domain_padding_mode : str {'symmetric', 'one-sided'}, defaults to 'one-sided'
+            How to perform domain padding. 
+        fno_fft_norm : str, defaults to 'forward'
+            normalization parameter of torch.fft to use in FNO. Defaults to 'forward'
+        fno_SpectralConv : nn.Module, defaults to SpectralConv
+             Spectral Convolution module to use.
         """
     
     

--- a/neuralop/models/fnogno.py
+++ b/neuralop/models/fnogno.py
@@ -196,8 +196,6 @@ class FNOGNO(nn.Module):
             out_p_embed = out_p #.reshape((n_out, -1))
         
         #(n_1*n_2*..., fno_hidden_channels)
-        #latent_embed = latent_embed.reshape(self.fno.hidden_channels, -1).t()
-        #latent_embed = latent_embed.permute(1, 2, 3, 0).reshape(-1, self.fno.hidden_channels)
         latent_embed = latent_embed.permute(*self.in_coord_dim_reverse_order, 0).reshape(-1, self.fno.hidden_channels)
 
         #(n_out, fno_hidden_channels)

--- a/neuralop/models/model_dispatcher.py
+++ b/neuralop/models/model_dispatcher.py
@@ -90,7 +90,7 @@ def dispatch_model(ModelClass, config):
         if (value.default is not inspect._empty) and (key not in config):
             print(
                 f"Keyword argument {key} not specified for model {model_name}, "
-                f"using default={value.default}."
+                f"using {value.default=}."
             )
             # warnings.warn(
             #     f"Keyword argument {key} not specified for model {model_name}, "

--- a/neuralop/models/model_dispatcher.py
+++ b/neuralop/models/model_dispatcher.py
@@ -59,7 +59,7 @@ def get_model(config):
     try:
         return dispatch_model(MODEL_ZOO[arch], config_arch)
     except KeyError:
-        raise ValueError(f"Got config.arch={arch}, expected one of {MODEL_ZOO.keys}.")
+        raise ValueError(f"Got config.{arch=}, expected one of {MODEL_ZOO.keys}.")
 
 
 def dispatch_model(ModelClass, config):
@@ -82,10 +82,8 @@ def dispatch_model(ModelClass, config):
     # Verify that given parameters are actually arguments of the model
     for key in config:
         if key not in sig.parameters:
-            print(f"Given argument key={key} "
-                  f"that is not in {model_name}'s signature.")
-            # warnings.warn(f"Given argument {key=} "
-            #               f"that is not in {model_name}'s signature.")
+            print(f"Given argument {key=} that is not in {model_name}'s signature.")
+            # warnings.warn(f"Given argument {key=} that is not in {model_name}'s signature.")
 
     # Check for model arguments not specified in the configuration
     for key, value in sig.parameters.items():

--- a/neuralop/training/torch_setup.py
+++ b/neuralop/training/torch_setup.py
@@ -31,7 +31,8 @@ def setup(config):
 
         #Ensure every iteration has the same amount of data 
         assert(config.data.n_train % config.data.batch_size == 0), (
-            f'The number of training samples={config.data.n_train} cannot be divided by the batch_size={config.data.batch_size}.'
+            f'The number of training samples={config.data.n_train} '
+            f'cannot be divided by the batch_size={config.data.batch_size}.'
         )
         for j in range(len(config.data.test_batch_sizes)):
             assert(config.data.n_tests[j] % config.data.test_batch_sizes[j] == 0), (

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -17,7 +17,7 @@ class UnitGaussianNormalizer:
         
         if verbose:
             print(f'UnitGaussianNormalizer init on {n_samples}, reducing over {reduce_dim}, samples of shape {shape}.')
-            print(f'   Mean and std of shape {self.mean.shape}, eps={eps}')
+            print(f'   Mean and std of shape {self.mean.shape}, {eps=}')
 
     def encode(self, x):
         # x = x.view(-1, *self.sample_shape)

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -129,7 +129,7 @@ elif config.opt.scheduler == "StepLR":
         optimizer, step_size=config.opt.step_size, gamma=config.opt.gamma
     )
 else:
-    raise ValueError(f"Got scheduler={config.opt.scheduler}")
+    raise ValueError(f"Got {config.opt.scheduler=}")
 
 
 # Creating the losses

--- a/scripts/train_navier_stokes.py
+++ b/scripts/train_navier_stokes.py
@@ -133,7 +133,7 @@ elif config.opt.scheduler == "StepLR":
         optimizer, step_size=config.opt.step_size, gamma=config.opt.gamma
     )
 else:
-    raise ValueError(f"Got scheduler={config.opt.scheduler}")
+    raise ValueError(f"Got {config.opt.scheduler=}")
 
 
 # Creating the losses


### PR DESCRIPTION
Migrate the example file [`fourier_1d.py`](https://github.com/neuraloperator/neuraloperator/blob/master/fourier_1d.py) from the old master branch to [`main:examples`](https://github.com/neuraloperator/neuraloperator/tree/main/examples) as `plot_burgers.py` [1]. 

* Add `.npz` loader utilities to the `datasets/` module. Reshape the old data for the newest version of the library.
* Add support to `layers/` for float64 and complex128 numbers.

Based on top of https://github.com/m4e7/neuraloperator/pull/5

Reviewer(s): @zongyi-li @JeanKossaifi

[1] [plot_burgers.html.gz](https://github.com/m4e7/neuraloperator/files/12443738/plot_burgers.html.gz)
